### PR TITLE
Fix tab bar overlapping with error messages

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -4,7 +4,7 @@
 .tab-bar {
   height: @tab-bar-height;
   background: @tab-bar-background-color;
-  z-index: 1002;
+  z-index: 999;
 
   .tab {
     transition: all 200ms linear;


### PR DESCRIPTION
I noticed that error messages are not displayed properly, because the z-index of the tab bar ( 1002 ) is bigger than the index of error messages ( 1000 ).
![screenshot](https://cloud.githubusercontent.com/assets/7817714/6729879/2610a5a6-ce37-11e4-95de-291b2ce83977.png)
